### PR TITLE
Use _FILE_OFFSET_BITS=64 instead of _LARGEFILE64_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 EXECUTABLE := luksipc
 CC := gcc
-CFLAGS := -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -std=c11 -O2 -D_LARGEFILE64_SOURCE -D_XOPEN_SOURCE=500
+CFLAGS := -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -std=c11 -O2 -D_FILE_OFFSET_BITS=64 -D_XOPEN_SOURCE=500
 #CFLAGS += -DDEVELOPMENT -g
 
 LDFLAGS :=

--- a/chunk.c
+++ b/chunk.c
@@ -48,8 +48,8 @@ void freeChunk(struct chunk *aChunk) {
 	memset(aChunk, 0, sizeof(struct chunk));
 }
 
-static bool checkedSeek(int aFd, off64_t aOffset, const char *aCaller) {
-	off64_t curOffset = lseek64(aFd, aOffset, SEEK_SET);
+static bool checkedSeek(int aFd, off_t aOffset, const char *aCaller) {
+	off_t curOffset = lseek(aFd, aOffset, SEEK_SET);
 	if (curOffset != aOffset) {
 		logmsg(LLVL_WARN, "%s: tried seek to 0x%lx, went to 0x%lx (%s)\n", aCaller, aOffset, curOffset, strerror(errno));
 		return false;


### PR DESCRIPTION
The later makes lseek64() and off64_t available while the former makes
sizeof(off_t) == 8.

Fix #3.