### PR TITLE
Fixed 'Cannot remove device mapper handle ...' error message.

### DIFF
--- a/luks.c
+++ b/luks.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <libgen.h>
 
 #include "exec.h"
 #include "luks.h"
@@ -52,10 +53,13 @@ bool isLuks(const char *aBlockDevice) {
 /* Returns if the given device mapper name is available (i.e. not active at the
  * moment) */
 bool isLuksMapperAvailable(const char *aMapperName) {
+        char *bname;
+        bname = basename(aMapperName);
+
 	const char *arguments[] = {
 		"cryptsetup",
 		"status",
-		aMapperName,
+		bname,
 		NULL
 	};
 


### PR DESCRIPTION
In luks.c (row 223) the function isLuksMapperAvailable is
called with the full path of the device mapper
(including /dev/mapper/). In isLuksMapperAvailable a
'cryptsetup status' is performed with that input.
However, if you call 'cryptsetup status' with the full
path instead of the actual name of the device mapper it
will (at least on RHEL 6) return 1 (wrong parameters) as
error code, not 4 (wrong device specified). And the
user will receive the "Cannot remove device mapper handle
..." error message. The fix is to strip the
/dev/mapper part and only run 'cryptsetup status' using
the basename.
